### PR TITLE
12 add uid

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+produced with the help of the following:
+
+Paradise Killer OST
+https://www.youtube.com/watch?v=UBvmZTIsW64&list=PLwuYDFx9W0sFKMgMvXBfnOLU2qbKJqHIj

--- a/classes/airport.py
+++ b/classes/airport.py
@@ -13,11 +13,12 @@ class Airport:
         self.locid = locid
         self.hub = hub
         self.enplaned = enplaned
-        self.cbsa = cbsa
-        self.fips = fips
+        self.cbsa_code = cbsa
+        self.fips_code = fips
+        self.uid = None # assigned in process_inputs/build_uids.py
 
     def __repr__(self):
-        return f'Airport({self.locid}; name: {self.name}; location: {self.city}, {self.state}; hub: {self.hub}; enplaned: {self.enplaned}; cbsa: {self.cbsa}, fips: {self.fips}\n'
+        return f'Airport({self.locid}; name: {self.name}; location: {self.city}, {self.state}; hub: {self.hub}; enplaned: {self.enplaned}; cbsa: {self.cbsa_code}, fips: {self.fips_code}\n'
 
     @classmethod
     def by_state(cls, state):
@@ -29,5 +30,3 @@ class Airport:
         for state in helpers.ALL_US_STATES:
             count[state] = len(cls.by_state(state))
         return count
-
-

--- a/classes/airport.py
+++ b/classes/airport.py
@@ -1,6 +1,6 @@
 import shared.helpers as helpers
 
-# there are 368 NPIAS hub-ranked airports from 2017-2021. I omit one, "Block Is;and" in RI, for a total of 367.
+# there are 368 NPIAS hub-ranked airports from 2017-2021. I omit one, "Block Island" in RI, for a total of 367.
 
 class Airport:
     # key is locid

--- a/classes/cbsa.py
+++ b/classes/cbsa.py
@@ -6,11 +6,12 @@ class Cbsa:
     def __init__(self, code, name, msa_designation, fips = None):
         self.code = code
         self.name = name
-        self.msa_designation = msa_designation
-        self.fips = set()
+        self.msa_designation = msa_designation # metro/micro
+        self.uid = None # populated by process_inputs/build_uids.py
+        self.fips_codes = set()
         if fips:
-            self.fips.add(fips) # python wants to turn a string into a list of chars >:(, can't initialize with a string
+            self.fips_codes.add(fips) # python wants to turn a string into a list of chars >:(, can't initialize with a string
         self.airports = set()
         
     def __repr__(self):
-        return f'Cbsa("{self.code}", "{self.name}", "{self.msa_designation}", fips: {self.fips})'
+        return f'Cbsa("{self.code}", "{self.name}", "{self.msa_designation}", fips: {self.fips_codes})'

--- a/classes/fips.py
+++ b/classes/fips.py
@@ -6,9 +6,12 @@ class Fips:
         self.code = code
         self.county = county 
         self.state = state
-        self.cbsa = cbsa
+        self.cbsa_code = cbsa
         self.class_code = class_code # see doc for details - unused currently
-        self.airports = set()
+        self.uid = None # populated by process_inputs/build_uids.py
+        self.airports = set() # conditionally populated by process_inputs/airports.py
+        self.adjacent_fips = set() # populated by process_inputs/fips_adjacency.py in next step
+        self.adjacent_uids = set() # populated by process_inputs/fips_adjacency.py in next step
 
     def __repr__(self):
         return f'FIPS({self.code}: {self.county}, {self.state}, cbsa: {self.cbsa}, class code: {self.class_code}, airports: {self.airports})'

--- a/classes/fips.py
+++ b/classes/fips.py
@@ -2,20 +2,12 @@ class Fips:
     # list of all FIPS by code
     collection = {}
 
-    # hit this with a FIPS code to get the CBSA code if it exists, or return the FIPS if it doesn't. Used for accessing the oranges table.
-    @classmethod
-    def get_code(fips_code):
-        if fips_code in collection:
-            return collection[fips_code].cbsa
-        else: 
-            return fips_code
-
     def __init__(self, code, county, state, class_code, cbsa = None):
         self.code = code
         self.county = county 
         self.state = state
         self.cbsa = cbsa
-        self.class_code = class_code
+        self.class_code = class_code # see doc for details - unused currently
         self.airports = set()
 
     def __repr__(self):

--- a/classes/uid.py
+++ b/classes/uid.py
@@ -1,15 +1,28 @@
+from classes.fips import Fips
+
+# this class is a "universal identifier" for the regions considered in this project. Each one represents a CBSA if applicable, and if not, the FIPS inbetween
+
 class Uid:
 
     collection = {}
+    __uid_counter = -1 
 
-    def __init__(self. uid_code, category):
-        self.uid = uid_code
-        self.category = category # "F" = FIPS, "C" = CBSA
+    @classmethod
+    def __get_next_uid(cls):
+        cls.__uid_counter +=1
+        return cls.__uid_counter
+
+    def __init__(self, category):
+        category = category.upper()
+        if category in ["FIPS", "F"]:
+            self.category = "F"
+        elif category in ["CBSA", "C"]:
+            self.category = "C"
+        else:
+            raise ValueError("Must pass 'fips' or 'cbsa' when creating a new UID")
+
+        self.code = Uid.__get_next_uid() 
         self.adjacent = set() # geographically adjacent counties by UID
         self.airports = set() # airports located within this region
-
-#    @classmethod
-#    def lookup_by_fips(cls, fips):
-
-#    def edges():
-        # return an Edges.collection[uid] call, do not store twice
+        self.fips_codes  = set() # any fips contained
+        self.cbsa_codes = set() # any cbsa contained

--- a/classes/uid.py
+++ b/classes/uid.py
@@ -1,0 +1,15 @@
+class Uid:
+
+    collection = {}
+
+    def __init__(self. uid_code, category):
+        self.uid = uid_code
+        self.category = category # "F" = FIPS, "C" = CBSA
+        self.adjacent = set() # geographically adjacent counties by UID
+        self.airports = set() # airports located within this region
+
+#    @classmethod
+#    def lookup_by_fips(cls, fips):
+
+#    def edges():
+        # return an Edges.collection[uid] call, do not store twice

--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ import process_inputs.fips_counties as fc
 import process_inputs.cbsa_fips_mapping as cbsa
 import process_inputs.fips_place_cbsa as fpc 
 import process_inputs.airports as air
-#import process_inputs.fips_adjacency as fa
+import process_inputs.build_uids as bu
+import process_inputs.fips_adjacency as fa
 
 # 01 - fips_counties.py
 # first: read in a complete list of all FIPS in the US - there are 3,235 in this file
@@ -20,14 +21,15 @@ place_cbsa = fpc.build_fips_maps()
 # 4 - airports
 # complete
 airports = air.process_airports(place_cbsa)
+del place_cbsa # need to check if there are other references out there - this file is only used to process airports
 
-
-# 5 - fips_adjacency
+# 5 - process FIPS adjacency file and update ajacent counties for each Fips instance 
 # complete
-#adjacent = fa.build_fips_adjacency()
+fa.build_fips_adjacency()
 
-# 6 - uid_adjacency
-# not started
+# 6 - construct UIDs
+# in progress
+bu.process_fips_for_uid()
 
 print("you are in main")
 breakpoint()

--- a/main.py
+++ b/main.py
@@ -1,24 +1,25 @@
-#import process_inputs.fips_adjacency as fa
-#import process_inputs.cbsa_fips_mapping as cbsa
-#import process_inputs.fips_place_cbsa as fpc 
-#import process_inputs.airports as air
 import process_inputs.fips_counties as fc
+import process_inputs.cbsa_fips_mapping as cbsa
+import process_inputs.fips_place_cbsa as fpc 
+import process_inputs.airports as air
+#import process_inputs.fips_adjacency as fa
 
-# 01 - fips_counties
+# 01 - fips_counties.py
 # first: read in a complete list of all FIPS in the US - there are 3,235 in this file
 fc.build_fips()
 
-# 02 - cbsa_fips_mapping
+# 02 - cbsa_fips_mapping.py
 #complete
-#fips_cbsa, cbsa_map = cbsa.build_CBSA_maps()
+cbsa.build_CBSA_maps()
 
 # 3 - fips_place_cbsa
 # complete
-#place_cbsa = fpc.build_fips_maps()
+# returns a lookup for place_cbsa["place name"] -> [fips_code, cbsa_code]
+place_cbsa = fpc.build_fips_maps()
 
 # 4 - airports
 # complete
-#airports = air.process_airports(place_cbsa)
+airports = air.process_airports(place_cbsa)
 
 
 # 5 - fips_adjacency

--- a/process_inputs/build_uids.py
+++ b/process_inputs/build_uids.py
@@ -1,0 +1,28 @@
+from classes.uid import Uid
+from classes.fips import Fips
+from classes.cbsa import Cbsa
+from classes.airport import Airport
+
+def process_fips_for_uid():
+    for [fips_code, fips] in Fips.collection.items():
+        if fips.cbsa_code == None:
+            uid = Uid("FIPS")
+            uid.airports.union(fips.airports)
+        else:
+            cbsa = Cbsa.collection[fips.cbsa_code]
+            uid = Uid("CBSA")
+            uid.airports.union(cbsa.airports)
+            # associate CBSA with UID 
+            cbsa.uid = uid.code
+
+        uid.cbsa_codes.add(fips.cbsa_code)
+        uid.fips_codes.add(fips_code)
+        # associate the FIPS with the UID
+        fips.uid = uid.code
+
+        # associate airports with a uid
+        for airport in uid.airports:
+            Airport.collection[airport].uid = uid.code
+
+        # collect the uid for safekeeping
+        Uid.collection[uid.code] = uid

--- a/process_inputs/cbsa_fips_mapping.py
+++ b/process_inputs/cbsa_fips_mapping.py
@@ -67,7 +67,7 @@ def build_CBSA_maps():
             Fips.collection[full_fips].cbsa = code # map fips -> cbsa code 
             if (code in Cbsa.collection):
                 # have seen this CBSA before, update the list of FIPS assigned
-                Cbsa.collection[code].fips.add(full_fips) 
+                Cbsa.collection[code].fips_codes.add(full_fips) 
             else:
                 # create new CBSA entry
                 mycbsa = Cbsa(code, name, msa, full_fips)

--- a/process_inputs/cbsa_fips_mapping.py
+++ b/process_inputs/cbsa_fips_mapping.py
@@ -3,13 +3,13 @@ import pandas as pd
 import shared.utils as utils
 import shared.helpers as helpers
 from classes.cbsa import Cbsa
+from classes.fips import Fips
 
 inputs = utils.get_inputs_dir()
 
 pd.set_option('display.width', 200)
 pd.set_option('display.max_columns', None)
 
-file_path_fips_lookup = inputs.joinpath("jhu", "UID_ISO_FIPS_LookUp_Table.csv")
 file_path_cbsa_list1 = inputs.joinpath("census", "list1_2015", "list1.xls")
 # the first 10 chars indicate list1 is an MS-OLE2 encoded file from Excel 97. This format is extraordinarily difficult for python to parse.
 # $ print(repr(open(file_path_cbsa_list1, 'rb').read(10)))
@@ -60,14 +60,11 @@ def build_CBSA_maps():
     # County Name -> CBSA code ---- the way the county names are entered is chaotic, and I can better easily scrape them from another file. It is too much work to clean the names as they appear on this list
     # CBSA Code -> CBSA object  -- this is being done under Cbsa.collection
 
-    fips_cbsa = {}
-    county_to_cbsa = {}
-
     for row in mycsv.splitlines():
         code, name, msa, county_name, state, fips_state, fips_county, location = row.split(",")
         if fips_state in helpers.ALL_US_FIPS:
             full_fips = fips_state + fips_county 
-            fips_cbsa[full_fips] = code # map fips -> cbsa code 
+            Fips.collection[full_fips].cbsa = code # map fips -> cbsa code 
             if (code in Cbsa.collection):
                 # have seen this CBSA before, update the list of FIPS assigned
                 Cbsa.collection[code].fips.add(full_fips) 
@@ -75,4 +72,3 @@ def build_CBSA_maps():
                 # create new CBSA entry
                 mycbsa = Cbsa(code, name, msa, full_fips)
                 Cbsa.collection[code] = mycbsa
-    return (fips_cbsa, county_to_cbsa)

--- a/process_inputs/fips_adjacency.py
+++ b/process_inputs/fips_adjacency.py
@@ -13,7 +13,7 @@ inputs = utils.get_inputs_dir()
 file_path_fips_adjacency = inputs.joinpath("census", "county_adjacency.txt")
 
 def build_fips_adjacency():
-    edges = {}
+    adjacent = {}
     with open(file_path_fips_adjacency, encoding='cp1252', newline='') as file:
         reader = csv.reader(file, delimiter='\t')
         for row in reader:
@@ -21,7 +21,7 @@ def build_fips_adjacency():
                 break
             elif row[1]: # if there is an entry in col 1, then this is begins a new edges entry 
                 curr = int(row[1])
-                edges[curr] = []
+                ajacent[curr] = set() 
             else: # there is no fips in col 1 and we are in the middle of assigning edges
-                edges[curr].append(int(row[3]))
-    return edges 
+                adjacent[curr].append(int(row[3]))
+    return adjacent 

--- a/process_inputs/fips_adjacency.py
+++ b/process_inputs/fips_adjacency.py
@@ -1,7 +1,11 @@
+# this file reads in the adjacency file and updates the FIPS so they contain their own adjacent FIPS
+
 import csv
 
 # local imports
 import shared.utils as utils
+import shared.helpers as helpers
+from classes.fips import Fips
 
 inputs = utils.get_inputs_dir() 
 # note that this file is a windows encoded text file, ie windows-1252
@@ -10,18 +14,20 @@ inputs = utils.get_inputs_dir()
 # [1] - fips
 # [2] - name of adjacent county
 # [3] - fips of adjacent county
-file_path_fips_adjacency = inputs.joinpath("census", "county_adjacency.txt")
+file_path_fips_adjacency = inputs.joinpath("census", "county_adjacency_2010","county_adjacency.txt")
 
 def build_fips_adjacency():
     adjacent = {}
     with open(file_path_fips_adjacency, encoding='cp1252', newline='') as file:
         reader = csv.reader(file, delimiter='\t')
         for row in reader:
-            if row[1]=="72001": # if we hit Puerto Rico, we are done
-                break
-            elif row[1]: # if there is an entry in col 1, then this is begins a new edges entry 
+            if row[0]: # if there is an entry in col 0, then this is begins a new adjacency entry 
+                county, state = row[0].split(',')
+                if state not in helpers.ALL_US_STATES:
+                    continue # skip non-US states
                 curr = int(row[1])
-                ajacent[curr] = set() 
-            else: # there is no fips in col 1 and we are in the middle of assigning edges
-                adjacent[curr].append(int(row[3]))
-    return adjacent 
+            else: # there is no fips in col 0, then we are in the middle of assigning adjacencies 
+                county, state = row[2].split(',')
+                if state not in helpers.ALL_US_STATES:
+                    continue # skip non-US states
+                Fips.collection[curr].adjacent.append(row[3])

--- a/process_inputs/fips_counties.py
+++ b/process_inputs/fips_counties.py
@@ -8,6 +8,9 @@ inputs = utils.get_inputs_dir()
 
 file_path_county_fips = inputs.joinpath("census", "county_fips", "national_county.txt")
 
+# if begin tracking mystery lookups or Utah, use this file
+#file_path_fips_lookup = inputs.joinpath("jhu", "UID_ISO_FIPS_LookUp_Table.csv")
+
 # columns
 # 0: 2 char state code, 1: fips state code, 2: fips county code, 3: county name, 4: class_code
 
@@ -17,7 +20,7 @@ def build_fips():
         for row in reader:
             state, fips_state, fips_county, county_name, class_code = row
             
-            if state not in helpers.ALL_US_STATES: continue; # skip AS, GU, MP, VI, PR, UM 
+            if state not in helpers.ALL_US_STATES: continue # skip AS, GU, MP, VI, PR, UM 
             full_fips = fips_state + fips_county
             myfips = Fips(full_fips, county_name, state, class_code) 
             Fips.collection[full_fips] = myfips

--- a/process_inputs/fips_place_cbsa.py
+++ b/process_inputs/fips_place_cbsa.py
@@ -1,6 +1,7 @@
 ###
 #
-# this file produces a place -> cbsa lookup as a dict with place_cbsa[place_name] -> returns cbsa_code or FIPS code if no CBSA
+# this file produces lookup place_cbsa[place_name] -> [cbsa_code , FIPS code] 
+# used for 
 #
 ###
 import pandas as pd


### PR DESCRIPTION
closes #12 Add Uids
- renamed fips to fips_code and cbsa to cbsa_code when referring just to the identifier, so that fips or cbsa always refers to an object of that class
- all FIPS assigned to a UID
- all CBSAs assigned to a UID
- all airports assigned to a UID